### PR TITLE
Removed code for explicit Nuxt 3 version check

### DIFF
--- a/packages/pdf-frame-nuxt/src/module.ts
+++ b/packages/pdf-frame-nuxt/src/module.ts
@@ -1,5 +1,7 @@
 import { defineNuxtModule, addComponent, createResolver, isNuxt3 } from '@nuxt/kit'
 
+const { resolve } = createResolver(import.meta.url)
+
 // Module options TypeScript interface definition
 export interface ModuleOptions {}
 
@@ -25,16 +27,10 @@ export default defineNuxtModule<ModuleOptions>({
     }
   },
   defaults: {},
-  async setup (options, nuxt) {
-    if (!isNuxt3(nuxt)) {
-      console.error("nuxt-pdf-frame compatible with Nuxt 3");
-      return;
-    }
-
-    const resolver = createResolver(import.meta.url)
+  async setup () {
     addComponent({
       name: 'pdfFrame',
-      filePath: resolver.resolve('./runtime/components/pdf-frame')
+      filePath: resolve('./runtime/components/pdf-frame')
     })
   }
 })


### PR DESCRIPTION
Removed code that was responsible for the Nuxt 3 version check. This should allow the pdf-frame-nuxt package to work with Nuxt 4.